### PR TITLE
Fix config loader bug

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include ctdcal/_version.py
+include ctdcal/user_settings.yaml

--- a/README.md
+++ b/README.md
@@ -13,49 +13,57 @@ for in-situ sensors used for ocean measurement.
 ---
 
 ## Installation
-### Clone repository
-Pull down the latest version of ctdcal:
+ctdcal can be installed using pip:
 
 ```
-git clone https://github.com/cchdo/ctdcal.git
+$ pip install ctdcal
 ```
 
-### Install ctdcal and dependencies
-Change directories to the top-level ctdcal:
+---
 
-```
-cd ctdcal
-```
-
-Create a new virtual environment with your preferred environment manager and install with pip:
-
-```
-pip install .
-```
-
-Note: there is an occasional (conda?) bug where CLI tools are not immediately accessible after install – this can usually be remedied by deactivating and reactiving the virtual environment.
-
+## CLI usage
+### Initialize data folders
 Initialize default `/data/` folders by running:
 
 ```
-ctdcal init
+$ ctdcal init
 ```
 
 (Future versions of ctdcal are planned have more robust init options/flags/etc.)
 
----
-
-## Usage
 ### Import and process data
 To process data, copy over raw `.hex` and `.xmlcon` files into `/data/raw/` and reference data to their appropriate folder (`oxygen`, `reft`, `salt`).
 
 Users can process their data with individual ctdcal functions or try:
 
 ```
-ctdcal process [--group ODF]
+$ ctdcal process [--group ODF]
 ```
 
 to process using ODF procedures.
+
+---
+
+## Package usage
+### Explore user settings
+Most ctdcal functions get settings from `user_settings.yaml` and subsequently `config.py`. Call the configuration loader to explore default settings:
+
+```py
+from ctdcal import get_ctdcal_config
+cfg = get_ctdcal_config()
+
+# directories for I/O purposes
+print(cfg.dirs)
+print(cfg.fig_dirs)
+
+# experiment-specific settings (e.g., expocode, CTD serial number) from user_settings.yaml
+print(cfg.settings)
+
+# dictionary mapping of short/long column names
+print(cfg.columns)
+```
+
+As ctdcal continues to be developed, more robust [tutorials](https://ctdcal.readthedocs.io/en/latest/tutorials.html) will be added to [our documentation](https://ctdcal.readthedocs.io/en/latest/).
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,46 @@
+This is a lightweight guide for testing and publishing a new release.
+
+## Test release on TestPyPI
+
+Tag current commit with a new, unused test version name
+
+```
+$ git tag -a v0.1.0b8 -m ""
+```
+
+Build distribution
+
+```
+$ python -m build
+```
+
+Upload using twine
+
+```
+$ twine upload --repository testpypi dist/ctdcal-0.1.0b8
+```
+
+When prompted:
+```
+username = __token__
+password = TestPyPI API key
+```
+
+Visit https://test.pypi.org/project/ctdcal/0.1.0b8/ to ensure test release was successful.
+
+## Full release on PyPI with GitHub Actions
+
+Checkout and tag commit to be released with appropriate version number (vX.Y.Z)
+
+```
+$ git checkout _hash_
+$ git tag -a v0.2.0 -m ""
+```
+
+Assuming commit is already pushed, now push tags to remote
+
+```
+$ git push --tags
+```
+
+[Create a new release](https://github.com/cchdo/ctdcal/releases/new) on GitHub, which should automatically trigger an Action to publish to PyPI (see [.github/workflows/](https://github.com/cchdo/ctdcal/tree/master/.github/workflows)).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,9 @@
    API reference <api>
    Contribute on GitHub <https://github.com/cchdo/ctdcal>
 
+************************************************
 ctdcal: Process and calibrate CTD data in Python
-================================================
+************************************************
 
 This package is under development by the `Oceanographic Data Facility (ODF) <https://scripps.ucsd.edu/ships/shipboard-technical-support/odf>`_ group at `Scripps Institution of Oceanography (SIO) <https://scripps.ucsd.edu/>`_. ODF uses data processing software and techniques that were developed internally and provide exceptional fitting of CTD and hydrographic data. The software is regularly updated to take full advantage of the latest coding standards and improvements.
 
@@ -19,22 +20,51 @@ The software is all-encompassing with the ability to process raw data, perform q
 
 Installation
 ============
-``ctdcal`` can be installed using Git and pip as follows:
+``ctdcal`` can be installed using pip::
+   
+   $ pip install ctdcal
 
-Pull down the latest version of ctdcal:
-   >>> git clone https://github.com/cchdo/ctdcal.git
 
-Change directories to the top-level ctdcal:
-   >>> cd ctdcal
+CLI usage
+=========
+Initialize data folders
+-----------------------
+Initialize default `/data/` folders by running::
 
-Create a new virtual environment with your preferred environment manager and install dependencies with pip:
-   >>> pip install .
+   $ ctdcal init
 
-.. note::
-   Note: there is an occasional (conda?) bug where CLI tools are not immediately accessible after install – this can usually be remedied by deactivating and reactiving the virtual environment.
+(Future versions of ctdcal are planned have more robust init options/flags/etc.)
 
-Initialize default `/data/` folders by running:
-   >>> ctdcal init
+Import and process data
+-----------------------
+To process data, copy over raw `.hex` and `.xmlcon` files into `/data/raw/` and reference data to their appropriate folder (`oxygen`, `reft`, `salt`).
+
+Users can process their data with individual ctdcal functions or try::
+
+   $ ctdcal process [--group ODF]
+
+to process using ODF procedures.
+
+Package usage
+=============
+Explore user settings
+---------------------
+Most ctdcal functions get settings from `user_settings.yaml` and subsequently `config.py`. Call the configuration loader to explore default settings::
+
+   from ctdcal import get_ctdcal_config
+   cfg = get_ctdcal_config()
+
+   # directories for I/O purposes
+   print(cfg.dirs)
+   print(cfg.fig_dirs)
+
+   # experiment-specific settings (e.g., expocode, CTD serial number) from user_settings.yaml
+   print(cfg.settings)
+
+   # dictionary mapping of short/long column names
+   print(cfg.columns)
+
+As ctdcal continues to be developed, more robust `tutorials <https://ctdcal.readthedocs.io/en/latest/tutorials.html>`_ will be added to `our documentation <https://ctdcal.readthedocs.io/en/latest/>`_.
 
 Indices and tables
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ python_requires = >=3.7
 packages =
     find:
 setup_requires = setuptools_scm
+include_package_data = True
 install_requires =
     cmocean==2.0
     click==8.0.1


### PR DESCRIPTION
`user_settings.yaml` was not included during packaging, causing `ctdcal.get_ctdcal_config()` to error out.
Fixed in manifest and setup.cfg