### PR TITLE
TestPyPI

### DIFF
--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.9
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: 3.8
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -1,6 +1,9 @@
 name: Publish tagged commits to TestPyPI
 
-on: push
+on:
+  push:
+    tags:
+      - v*.*.*
 
 jobs:
   publish:
@@ -15,8 +18,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip build
-        pip install twine
+        python -m pip install --upgrade pip build wheel twine
 
     - name: Build dists
       run: |

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -1,0 +1,34 @@
+name: Publish tagged commits to TestPyPI
+
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip build
+        pip install twine
+
+    - name: Build dists
+      run: |
+        python -m build .
+
+    - name: Test build and wheel
+      run: |
+        cd dist && pip install $(ls *.whl) && twine check *
+
+    - name: Publish distribution to TestPyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -34,3 +34,4 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+        skip_existing: True

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,32 +1,20 @@
 This is a lightweight guide for testing and publishing a new release.
 
-## Test release on TestPyPI
+## Test release on TestPyPI with GitHub Actions
 
-Tag current commit with a new, unused test version name
-
-```
-$ git tag -a v0.1.0b8 -m ""
-```
-
-Build distribution
+Assuming test branch is up to date and synced with remote, tag current commit with a new, unused test version name
 
 ```
-$ python -m build
+$ git tag -a v0.1.1b2 -m ""
 ```
 
-Upload using twine
+Push tags to remote to initialize TestPyPI action
 
 ```
-$ twine upload --repository testpypi dist/ctdcal-0.1.0b8
+$ git push --tags
 ```
 
-When prompted:
-```
-username = __token__
-password = TestPyPI API key
-```
-
-Visit https://test.pypi.org/project/ctdcal/0.1.0b8/ to ensure test release was successful.
+Visit https://github.com/cchdo/ctdcal/actions to ensure test release was successful.
 
 ## Full release on PyPI with GitHub Actions
 
@@ -37,7 +25,7 @@ $ git checkout _hash_
 $ git tag -a v0.2.0 -m ""
 ```
 
-Assuming commit is already pushed, now push tags to remote
+Assuming commit is already pushed, now push tags to remote (this will trigger the TestPyPI action above)
 
 ```
 $ git push --tags


### PR DESCRIPTION
Auto-publish tagged commits to TestPyPI and run Actions with python3.8 to solve [slow install issue](https://github.com/cchdo/ctdcal/runs/3693724669?check_suite_focus=true#step:7:1)