### PR TITLE
Fix failing Windows tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,9 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install .[dev]
+    - name: Run mypy
+      run: |
+        mypy -v --config-file pyproject.toml
     - name: Run pytest
       run: |
         pytest -v --cov-report xml --cov=ctdcal

--- a/ctdcal/tests/test_ctd_io.py
+++ b/ctdcal/tests/test_ctd_io.py
@@ -49,12 +49,12 @@ def test_write_pressure_details(tmp_path):
 
     # check only new data are appended (not another header)
     ctd_io.write_pressure_details("00201", f_path, "00:05:01", "00:09:01")
-    with open(f_path) as f:
+    with open(f_path, "rb") as f:
         contents = f.readlines()
         assert len(contents) == 3
-        assert "SSSCC" in contents[0]
-        assert "00101" in contents[1]
-        assert "00201" in contents[2]
+        assert b"SSSCC" in contents[0]
+        assert b"00101" in contents[1]
+        assert b"00201" in contents[2]
 
 
 def test_write_cast_details(tmp_path):
@@ -71,9 +71,9 @@ def test_write_cast_details(tmp_path):
     ctd_io.write_cast_details(
         "00201", f_path, 2.0, 3.0, 4.0, 0.0, 99.0, 6.0, -70.0, 170.0
     )
-    with open(f_path) as f:
+    with open(f_path, "rb") as f:
         contents = f.readlines()
         assert len(contents) == 3
-        assert "SSSCC" in contents[0]
-        assert "00101" in contents[1]
-        assert "00201" in contents[2]
+        assert b"SSSCC" in contents[0]
+        assert b"00101" in contents[1]
+        assert b"00201" in contents[2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,14 @@ write_to_template = 'version = "{version}"'
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+python_version = 3.8
+files = "ctdcal/ctd_io.py"
+
+[[tool.mypy.overrides]]
+module = [
+    "pandas",
+    "numpy"
+]
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ dev =
     black
     flake8
     isort
+    mypy
     pre-commit
     pytest
     pytest-cov


### PR DESCRIPTION
File open tests were failing on Windows, ended up being due to CR/LF characters.

Solved by [reading in binary mode](https://stackoverflow.com/a/9184137/13155619), although this doesn't feel like a real solution?