### PR TITLE
Fix broken tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     numpy==1.21.2
     pandas==1.3.3
     PyYAML==5.4.1
+    requests
     scipy==1.7.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     click==8.0.1
     gsw==3.4.0
     matplotlib==3.4.3
-    numpy==1.21.2
+    numpy
     pandas==1.3.3
     PyYAML==5.4.1
     requests


### PR DESCRIPTION
Failing appears to be due to pinned `numpy` version while `GSW` installation requirements has it unpinned, leading to version mismatching (1.21.2 vs. 1.22.#) in mypy.

Additional failure added by requiring `requests` package in `ctdcal.io` without adding to `setup.cfg`.